### PR TITLE
Switch from BCrypt to SCrypt

### DIFF
--- a/src/main/java/com/faendir/acra/security/SecurityConfiguration.java
+++ b/src/main/java/com/faendir/acra/security/SecurityConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 
@@ -71,7 +71,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @NonNull
     @Bean
     public static PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new SCryptPasswordEncoder();
     }
 
     @NonNull


### PR DESCRIPTION
In the year 2018, new applications should be using Argon2. If that is
not available, SCrypt is fine. Older algorithms like BCrypt should
no longer be used.

----

I'd suggest _not_ supporting multiple hash algorithms, and instead just make this update a hard update. After all, this is early stage software, as the readme states.