### PR TITLE
Allow to pass JAVA_OPTS environment variable

### DIFF
--- a/acrarium/Dockerfile
+++ b/acrarium/Dockerfile
@@ -13,4 +13,4 @@ RUN true
 COPY --from=builder application/snapshot-dependencies/ ./
 RUN true
 COPY --from=builder application/application/ ./
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "${JAVA_OPTS}", "org.springframework.boot.loader.JarLauncher"]


### PR DESCRIPTION
This would allow users of the docker container to adjust JVM options. e.g

```yml
version: "3.7"

services:
   acrarium:
       environment:
           JAVA_OPTS: "-Xmx 4G"
```

Fixes #149