### PR TITLE
Switch to JAVA_TOOL_OPTIONS

### DIFF
--- a/acrarium/Dockerfile
+++ b/acrarium/Dockerfile
@@ -13,4 +13,4 @@ RUN true
 COPY --from=builder application/snapshot-dependencies/ ./
 RUN true
 COPY --from=builder application/application/ ./
-ENTRYPOINT java ${JAVA_OPTS} org.springframework.boot.loader.JarLauncher
+ENTRYPOINT java org.springframework.boot.loader.JarLauncher

--- a/acrarium/docker-compose-debug.yml
+++ b/acrarium/docker-compose-debug.yml
@@ -14,4 +14,4 @@ services:
       SPRING_DATASOURCE_PASSWORD: 1qay2wsx
       SPRING_JPA_DATABASE-PLATFORM: org.hibernate.dialect.MariaDB10Dialect
       SPRING_APPLICATION_JSON: '{ "management": { "endpoints": { "enabled-by-default": true }, "endpoint": { "health": { "show-details": "always", "probes": { "enabled": true } } }, "health": { "livenessState": { "enabled": true }, "readinessState": { "enabled": true } } } }'
-      JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+      JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"


### PR DESCRIPTION
Drop the non-standard `JAVA_OPTS` and switch to `JAVA_TOOL_OPTIONS` which is supported by the JVM itself: https://docs.oracle.com/javase/8/docs/platform/jvmti/jvmti.html#tooloptions

``` 
Picked up JAVA_TOOL_OPTIONS: -Xms2G -Xmx5G
                                          _
     /\                                  (_)
    /  \      ___   _ __    __ _   _ __   _   _   _   _ __ ___
   / /\ \    / __| | '__|  / _` | | '__| | | | | | | | '_ ` _ \
  / ____ \  | (__  | |    | (_| | | |    | | | |_| | | | | | | |
 /_/    \_\  \___| |_|     \__,_| |_|    |_|  \__,_| |_| |_| |_|
```