### PR TITLE
Bugfix/Hotfix: Nullpointer when no Reports are Present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ pnpmfile.js
 /target
 .flattened-pom.xml
 /acrarium/vite.generated.ts
+
+### Frontend ###
+/acrarium/frontend/generated/*

--- a/acrarium/src/main/kotlin/com/faendir/acra/dataprovider/BugDataProvider.kt
+++ b/acrarium/src/main/kotlin/com/faendir/acra/dataprovider/BugDataProvider.kt
@@ -7,6 +7,7 @@ import com.faendir.acra.model.view.VBug
 import com.faendir.acra.util.sql
 import com.vaadin.flow.data.provider.SortDirection
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.stream.Stream
 import javax.persistence.EntityManager
 
@@ -48,9 +49,17 @@ class BugDataProvider(private val entityManager: EntityManager, private val app:
             val solvedVersionCode = it[3]
             val solvedVersionName = it[4]
             val reportCount = it[5]
-            val maxReportDate = it[6]
-            val maxVersionCode = it[7]
+            var maxReportDate = it[6]
+            var maxVersionCode = it[7]
             val userCount = it[8]
+
+            if(maxReportDate == null) {
+                maxReportDate = Timestamp.from(Instant.MIN);
+            }
+            if(maxVersionCode == null) {
+                maxVersionCode = -1;
+            }
+
             VBug(
                 bug = Bug(
                     id = (bugId as Number).toInt(),


### PR DESCRIPTION
After Deleting all Reports the Overview will throw an Nullpointer

Bugs are Existent, but no Reports (Delete Reports by Version)

```
acrarium    | java.lang.NullPointerException: null cannot be cast to non-null type java.sql.Timestamp
acrarium    | 	at com.faendir.acra.dataprovider.BugDataProvider.fetch(BugDataProvider.kt:61) ~[classes/:na]
acrarium    | 	at com.faendir.acra.dataprovider.AcrariumDataProvider.fetchFromBackEnd(AcrariumDataProvider.kt:11) ~[classes/:na]
acrarium    | 	at com.vaadin.flow.data.provider.AbstractBackEndDataProvider.fetch(AbstractBackEndDataProvider.java:61) ~[flow-data-23.2.3.jar:23.2.3]
```