### PR TITLE
Fix: /api/** and /swagger-ui/** unreachable — securityMatcher uses Ant syntax, not regex

### DIFF
--- a/acrarium/src/main/kotlin/com/faendir/acra/security/WebSecurityConfiguration.kt
+++ b/acrarium/src/main/kotlin/com/faendir/acra/security/WebSecurityConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2022-2024 Lukas Morawietz (https://github.com/F43nd1r)
+ * (C) Copyright 2022-2026 Lukas Morawietz (https://github.com/F43nd1r)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ class WebSecurityConfiguration(private val userRepository: UserRepository) : Vaa
     @Bean
     @Order(2)
     fun apiSecurityChain(http: HttpSecurity): SecurityFilterChain =
-        http.securityMatcher("/$API_PATH/.*")
+        http.securityMatcher("/$API_PATH/**")
             .csrf { it.disable() }
             .headers { it.disable() }
             .anonymous { it.disable() }
@@ -94,7 +94,7 @@ class WebSecurityConfiguration(private val userRepository: UserRepository) : Vaa
     @Bean
     @Order(3)
     fun actuatorSecurityChain(http: HttpSecurity, introspector: HandlerMappingIntrospector): SecurityFilterChain =
-        http.securityMatcher(OrRequestMatcher(EndpointRequest.toAnyEndpoint(), MvcRequestMatcher(introspector, ".*/swagger-ui/.*")))
+        http.securityMatcher(OrRequestMatcher(EndpointRequest.toAnyEndpoint(), MvcRequestMatcher(introspector, "/swagger-ui/**")))
             .csrf { it.disable() }
             .headers { it.disable() }
             .anonymous { it.disable() }


### PR DESCRIPTION
## Summary

Two `securityMatcher` patterns in `WebSecurityConfiguration.kt` are written as regex but the matchers parse them as Ant paths, so neither chain matches its intended endpoints. As a result the REST API (`/api/**`) and Swagger UI (`/swagger-ui/**`) are unreachable: requests miss the dedicated filter chains and fall through to the Vaadin catch-all, which redirects to `/login`.

## The bug

`acrarium/src/main/kotlin/com/faendir/acra/security/WebSecurityConfiguration.kt`

```kotlin
// L85 — API chain (Order 2)
http.securityMatcher(\"/\$API_PATH/.*\")

// L97 — Actuator + Swagger chain (Order 3)
MvcRequestMatcher(introspector, \".*/swagger-ui/.*\")
```

`HttpSecurity.securityMatcher(String)` builds an `AntPathRequestMatcher`, and `MvcRequestMatcher` also uses Ant path syntax. In Ant:

- `.` is a literal dot, not \"any char\"
- single-segment `*` matches zero+ non-slash chars
- `**` is the multi-segment wildcard

So `/api/.*` only matches a single segment that **starts with a literal dot** (`/api/.apps`, `/api/.x`), never `/api/apps` or `/api/apps/1/bugs`. `.*/swagger-ui/.*` is similarly broken.

## Evidence (before fix)

Reproduced against a deployed `master` instance with an API-role user:

| Request | Result | What it proves |
|---|---|---|
| `GET /api/apps` (valid creds) | 302 → `/login` | API chain didn't match; request fell to Vaadin catch-all |
| `GET /api/apps` (no creds) | 302 → `/login` | Same — auth never attempted |
| `GET /api/.apps` (valid creds) | 200, Vaadin SPA body | API chain DID match; auth succeeded; no controller mapped at `/.apps` |
| `GET /api/.apps` (wrong creds) | 401 | API chain matched and rejected — confirms basic-auth wiring works |
| `GET /api/./apps`, `/api//apps`, `/api/%2Eapps`, … | 400 from Tomcat | No client-side URL trick bypasses; strict path parsing rejects all variants |

The 401 row is the smoking gun: the filter chain is wired correctly, it just matches a disjoint set of paths from what the controllers expose.

## Fix

```diff
-        http.securityMatcher(\"/\$API_PATH/.*\")
+        http.securityMatcher(\"/\$API_PATH/**\")
```

```diff
-        http.securityMatcher(OrRequestMatcher(EndpointRequest.toAnyEndpoint(), MvcRequestMatcher(introspector, \".*/swagger-ui/.*\")))
+        http.securityMatcher(OrRequestMatcher(EndpointRequest.toAnyEndpoint(), MvcRequestMatcher(introspector, \"/swagger-ui/**\")))
```

## Verification (after fix)

Same deployed instance, rebuilt and redeployed with this patch:

| Request | Result |
|---|---|
| `GET /api/apps` (valid creds) | **`[1]`** (JSON array of app IDs) |
| `GET /api/apps/1` (valid creds) | `{\"id\":1,\"name\":\"…\",\"reporterUsername\":\"…\"}` |
| `GET /api/apps/1/bugs` (valid creds) | JSON array of bug IDs |
| `GET /api/apps` (wrong creds) | 401 |
| `GET /api/apps` (no creds) | 403 (the chain's `Http403ForbiddenEntryPoint`) |

## Test plan

- [ ] Existing security tests still pass
- [ ] `curl -u <api-user>:<pw> http://host/api/apps` returns JSON instead of redirecting
- [ ] `/swagger-ui/index.html` requires ADMIN auth and renders for ADMIN users